### PR TITLE
Ensure stub dir exists

### DIFF
--- a/app/Trade/Stub/Creator.php
+++ b/app/Trade/Stub/Creator.php
@@ -34,7 +34,9 @@ abstract class Creator
     {
         $fileName = $this->getFileName();
         $destination = $this->getDestinationDir();
-
+        
+        $this->files->ensureDirectoryExists($destination);
+        
         if (!$destination || !$fileName)
         {
             throw new \LogicException('Destination directory or filename was not set.');


### PR DESCRIPTION
Ensures stub destination directory exists before saving to prevent an error.