### PR TITLE
Reverse index order

### DIFF
--- a/app/Trade/Repository/SymbolRepository.php
+++ b/app/Trade/Repository/SymbolRepository.php
@@ -64,7 +64,7 @@ class SymbolRepository extends Repository
         }
 
         /** @noinspection PhpStrictTypeCheckingInspection */
-        $query = DB::table(DB::raw('candles USE INDEX(candles_symbol_id_t_unique)'))
+        $query = DB::table(DB::raw('candles USE INDEX(candles_t_symbol_id_unique)'))
             ->where('symbol_id', $symbolId)
             ->where('t', '>=', $startDate)
             ->where('t', '<=', $endDate);

--- a/database/migrations/2021_07_25_201837_create_candles_table.php
+++ b/database/migrations/2021_07_25_201837_create_candles_table.php
@@ -23,7 +23,7 @@ return new class extends Migration {
             $table->decimal('v');
             $table->index(['symbol_id', 'l']);
             $table->index(['symbol_id', 'h']);
-            $table->unique(['symbol_id', 't']);
+            $table->unique(['t', 'symbol_id']);
         });
     }
 


### PR DESCRIPTION
Reverses a critical index order on the candles table thus reducing query time by 3x.