### PR TITLE
PHP optimization

### DIFF
--- a/docker/8.1/Dockerfile
+++ b/docker/8.1/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
        php8.1-intl php8.1-readline \
        php8.1-ldap \
        php8.1-msgpack php8.1-igbinary php8.1-redis php8.1-swoole \
-       php8.1-memcached php8.1-pcov php8.1-xdebug php8.1-gmp \
+       php8.1-memcached php8.1-pcov php8.1-gmp \
     && pecl install trader \
     && php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
@@ -46,6 +46,8 @@ RUN apt-get update \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN #apt-get update && apt-get install -y php8.1-xdebug
 
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.1
 

--- a/docker/8.1/php.ini
+++ b/docker/8.1/php.ini
@@ -3,3 +3,5 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 extension = trader
+opcache.enable = 1
+opcache.enable_cli = 1


### PR DESCRIPTION
Disables Xdebug and enables Opcache by default. Xdebug command is commented in Dockerfile and can be uncommented to enable debugging on development environments.