### PR TITLE
Fix exit date/price when closing on exit setups on back-tests

### DIFF
--- a/app/Trade/Evaluation/TradeLoop.php
+++ b/app/Trade/Evaluation/TradeLoop.php
@@ -331,9 +331,21 @@ class TradeLoop
             if ($this->hasExitTrade() && $this->isClosesOnExit())
             {
                 $candle = $this->getLastCandle();
-                $priceDate = $this->getPriceDate($candle, null);
 
-                $this->overrideTargetPrice($position, $candle, $priceDate);
+                if ($this->isLastCandle($candle))
+                {
+                    //for live
+                    $targetPrice = $candle->c;
+                    $priceDate = $this->getPriceDate($candle, null);
+                }
+                else
+                {
+                    //for back-testing
+                    $targetPrice = $candle->o;
+                    $priceDate = $candle->t;
+                }
+
+                $this->overrideTargetPrice($position, $targetPrice, $priceDate);
                 $this->tryPositionExit($position, $candle, $priceDate);
             }
 
@@ -406,15 +418,15 @@ class TradeLoop
         }
     }
 
-    protected function overrideTargetPrice(Position $position, \stdClass $candle, int $priceDate): void
+    protected function overrideTargetPrice(Position $position, float $price, int $priceDate): void
     {
         if ($target = $position->price('exit'))
         {
-            $target->set((float)$candle->c, $priceDate, 'Target price overridden.', true);
+            $target->set($price, $priceDate, 'Target price overridden.', true);
         }
         else
         {
-            $this->status->setExitPrice((float)$candle->c, $priceDate);
+            $this->status->setExitPrice($price, $priceDate);
         }
     }
 

--- a/tests/Feature/Trade/Evaluation/TradeLoopTest.php
+++ b/tests/Feature/Trade/Evaluation/TradeLoopTest.php
@@ -76,7 +76,7 @@ class TradeLoopTest extends TestCase
         $exitTime = $position->exitTime();
         $this->assertNotNull($exitTime);
         //account for evaluation interval?
-        $this->assertEquals($exit->price_date, $exitTime);
+        $this->assertEquals($candles->last()->t, $exitTime);
     }
 
     public function test_run_with_config_param_timeout(): void


### PR DESCRIPTION
When using the option to close a trade when an exit setup is present, avoid using candle close date as the exit date and candle close price as the exit price on historical trades. Use candle open date and candle open price instead since we're supposed to exit the trade ASAP.